### PR TITLE
Add macOS and Linux shortcut backends

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,7 +34,19 @@ DEFAULT_CONFIG = {
             {"shortcut_str": "ctrl+alt+x", "action": "text_extraction"},
             {"shortcut_str": "ctrl+alt+c", "action": "table"},
             {"shortcut_str": "ctrl+alt+s", "action": "chem2smiles"},
-        ]
+        ],
+        "darwin": [
+            {"shortcut_str": "ctrl+alt+z", "action": "math2latex"},
+            {"shortcut_str": "ctrl+alt+x", "action": "text_extraction"},
+            {"shortcut_str": "ctrl+alt+c", "action": "table"},
+            {"shortcut_str": "ctrl+alt+s", "action": "chem2smiles"},
+        ],
+        "linux": [
+            {"shortcut_str": "ctrl+alt+z", "action": "math2latex"},
+            {"shortcut_str": "ctrl+alt+x", "action": "text_extraction"},
+            {"shortcut_str": "ctrl+alt+c", "action": "table"},
+            {"shortcut_str": "ctrl+alt+s", "action": "chem2smiles"},
+        ],
     },
 }
 os.chdir(os.path.dirname(os.path.abspath(sys.argv[0])))

--- a/readme.md
+++ b/readme.md
@@ -87,7 +87,7 @@ To make Im2Latex act like an installed application (accessible via Windows Searc
 
 ## Customizing Shortcuts
 
-Modify the default shortcut (`Win+Shift+Z`) by editing `config.json`:
+Modify the default shortcuts by editing `config.json`:
 1. Open `config.json` in the project folder.
 2. Update the `shortcuts` section, 'action' corresponds to a prompt for the LLM also defined in the config:
    ```json
@@ -105,10 +105,25 @@ Modify the default shortcut (`Win+Shift+Z`) by editing `config.json`:
                {"shortcut_str": "ctrl+alt+x", "action": "text_extraction"},
                {"shortcut_str": "ctrl+alt+c", "action": "table"},
                {"shortcut_str": "ctrl+alt+s", "action": "chem2smiles"}
+         ],
+         "darwin": [
+               {"shortcut_str": "ctrl+alt+z", "action": "math2latex"},
+               {"shortcut_str": "ctrl+alt+x", "action": "text_extraction"},
+               {"shortcut_str": "ctrl+alt+c", "action": "table"},
+               {"shortcut_str": "ctrl+alt+s", "action": "chem2smiles"}
+         ],
+         "linux": [
+               {"shortcut_str": "ctrl+alt+z", "action": "math2latex"},
+               {"shortcut_str": "ctrl+alt+x", "action": "text_extraction"},
+               {"shortcut_str": "ctrl+alt+c", "action": "table"},
+               {"shortcut_str": "ctrl+alt+s", "action": "chem2smiles"}
          ]
       }
    }
    ```
-3. Supported modifiers: `win`, `ctrl`, `alt`, `shift`  
+3. Supported modifiers:
+   - **Windows**: `win`, `ctrl`, `alt`, `shift`
+   - **macOS** (`darwin` config key): `cmd`, `ctrl`, `alt`/`option`, `shift`
+   - **Linux**: `super`/`win`, `ctrl`, `alt`, `shift`
    Supported keys: `a-z`, `0-9`
 

--- a/shortcuts.py
+++ b/shortcuts.py
@@ -1,10 +1,13 @@
 import platform
 import ctypes
-import ctypes.wintypes as wintypes
+import ctypes.util
 from PyQt5.QtCore import QAbstractNativeEventFilter
 
-# Windows constants
-WM_HOTKEY = 0x0312
+if platform.system() == "Windows":
+    import ctypes.wintypes as wintypes
+
+    # Windows constants
+    WM_HOTKEY = 0x0312
 
 
 class ShortcutBackend:
@@ -113,11 +116,438 @@ class WindowsShortcutBackend(ShortcutBackend):
         app.installNativeEventFilter(self.event_filter)
 
 
+class MacShortcutBackend(ShortcutBackend):
+    MODIFIER_MAP = {
+        "ctrl": 1 << 12,
+        "control": 1 << 12,
+        "alt": 1 << 11,
+        "option": 1 << 11,
+        "shift": 1 << 9,
+        "cmd": 1 << 8,
+        "win": 1 << 8,
+        "super": 1 << 8,
+    }
+
+    KEY_MAP = {
+        "a": 0x00,
+        "b": 0x0B,
+        "c": 0x08,
+        "d": 0x02,
+        "e": 0x0E,
+        "f": 0x03,
+        "g": 0x05,
+        "h": 0x04,
+        "i": 0x22,
+        "j": 0x26,
+        "k": 0x28,
+        "l": 0x25,
+        "m": 0x2E,
+        "n": 0x2D,
+        "o": 0x1F,
+        "p": 0x23,
+        "q": 0x0C,
+        "r": 0x0F,
+        "s": 0x01,
+        "t": 0x11,
+        "u": 0x20,
+        "v": 0x09,
+        "w": 0x0D,
+        "x": 0x07,
+        "y": 0x10,
+        "z": 0x06,
+        "0": 0x1D,
+        "1": 0x12,
+        "2": 0x13,
+        "3": 0x14,
+        "4": 0x15,
+        "5": 0x17,
+        "6": 0x16,
+        "7": 0x1A,
+        "8": 0x1C,
+        "9": 0x19,
+    }
+
+    kEventClassKeyboard = 0x6B657962
+    kEventHotKeyPressed = 6
+    kEventParamDirectObject = 0x2D2D2D2D
+    typeEventHotKeyID = 0x686B6964
+
+    class EventTypeSpec(ctypes.Structure):
+        _fields_ = [("eventClass", ctypes.c_uint32), ("eventKind", ctypes.c_uint32)]
+
+    class EventHotKeyID(ctypes.Structure):
+        _fields_ = [("signature", ctypes.c_uint32), ("id", ctypes.c_uint32)]
+
+    EventHandlerUPP = ctypes.CFUNCTYPE(
+        ctypes.c_int32, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p
+    )
+
+    def __init__(self):
+        carbon_path = ctypes.util.find_library("Carbon")
+        if not carbon_path:
+            raise RuntimeError("Carbon framework not found")
+        self.carbon = ctypes.CDLL(carbon_path)
+        self.carbon.GetApplicationEventTarget.restype = ctypes.c_void_p
+        self.carbon.InstallApplicationEventHandler.argtypes = [
+            self.EventHandlerUPP,
+            ctypes.c_uint32,
+            ctypes.POINTER(self.EventTypeSpec),
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_void_p),
+        ]
+        self.carbon.RegisterEventHotKey.argtypes = [
+            ctypes.c_uint32,
+            ctypes.c_uint32,
+            ctypes.POINTER(self.EventHotKeyID),
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+            ctypes.POINTER(ctypes.c_void_p),
+        ]
+        self.carbon.RegisterEventHotKey.restype = ctypes.c_int32
+        self.carbon.UnregisterEventHotKey.argtypes = [ctypes.c_void_p]
+        self.carbon.UnregisterEventHotKey.restype = ctypes.c_int32
+        self.carbon.GetEventParameter.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+            ctypes.c_uint32,
+            ctypes.POINTER(ctypes.c_uint32),
+            ctypes.c_uint32,
+            ctypes.POINTER(ctypes.c_uint32),
+            ctypes.c_void_p,
+        ]
+        self.carbon.GetEventParameter.restype = ctypes.c_int32
+
+        self.shortcuts = {}
+        self.hotkey_refs = {}
+        self.event_handler_ref = ctypes.c_void_p()
+        self.event_target = self.carbon.GetApplicationEventTarget()
+        self._handler_proc = self.EventHandlerUPP(self._handle_hotkey)
+        self._install_event_handler()
+
+    def _install_event_handler(self):
+        event_types = (self.EventTypeSpec * 1)(
+            self.EventTypeSpec(self.kEventClassKeyboard, self.kEventHotKeyPressed)
+        )
+        status = self.carbon.InstallApplicationEventHandler(
+            self._handler_proc,
+            1,
+            event_types,
+            None,
+            ctypes.byref(self.event_handler_ref),
+        )
+        if status != 0:
+            raise RuntimeError(f"Failed to install hotkey handler (status={status})")
+
+    def _handle_hotkey(self, handler_call_ref, event_ref, user_data):
+        hotkey_id = self.EventHotKeyID()
+        status = self.carbon.GetEventParameter(
+            event_ref,
+            self.kEventParamDirectObject,
+            self.typeEventHotKeyID,
+            None,
+            ctypes.sizeof(hotkey_id),
+            None,
+            ctypes.byref(hotkey_id),
+        )
+        if status == 0:
+            callback = self.shortcuts.get(hotkey_id.id)
+            if callback:
+                callback()
+        return 0
+
+    def install_shortcut(self, modifiers, key, shortcut_id, callback):
+        mod_value = 0
+        invalid_mods = [m for m in modifiers if m not in self.MODIFIER_MAP]
+        if invalid_mods:
+            raise ValueError(f"Unsupported modifiers: {set(invalid_mods)}")
+        for mod in modifiers:
+            mod_value |= self.MODIFIER_MAP[mod]
+
+        key_value = self.KEY_MAP.get(key.lower())
+        if key_value is None:
+            raise ValueError(f"Unsupported key: {key}")
+
+        hotkey_id = self.EventHotKeyID(0x494D324C, shortcut_id)  # 'IM2L'
+        hotkey_ref = ctypes.c_void_p()
+        status = self.carbon.RegisterEventHotKey(
+            key_value,
+            mod_value,
+            ctypes.byref(hotkey_id),
+            self.event_target,
+            0,
+            ctypes.byref(hotkey_ref),
+        )
+        if status == 0:
+            self.shortcuts[shortcut_id] = callback
+            self.hotkey_refs[shortcut_id] = hotkey_ref
+            return True
+        return False
+
+    def remove_shortcut(self, shortcut_id):
+        hotkey_ref = self.hotkey_refs.get(shortcut_id)
+        if not hotkey_ref:
+            return False
+        status = self.carbon.UnregisterEventHotKey(hotkey_ref)
+        if status == 0:
+            del self.hotkey_refs[shortcut_id]
+            del self.shortcuts[shortcut_id]
+            return True
+        return False
+
+    def process_message(self, msg):
+        return False
+
+    def install_event_handler(self, app):
+        # Carbon handler installed during initialization; nothing to do here.
+        return None
+
+
+class LinuxShortcutBackend(ShortcutBackend):
+    SHIFT_MASK = 1 << 0
+    LOCK_MASK = 1 << 1
+    CONTROL_MASK = 1 << 2
+    MOD1_MASK = 1 << 3
+    MOD2_MASK = 1 << 4
+    MOD4_MASK = 1 << 6
+
+    MODIFIER_MAP = {
+        "shift": SHIFT_MASK,
+        "ctrl": CONTROL_MASK,
+        "control": CONTROL_MASK,
+        "alt": MOD1_MASK,
+        "mod1": MOD1_MASK,
+        "win": MOD4_MASK,
+        "super": MOD4_MASK,
+    }
+
+    class XErrorEvent(ctypes.Structure):
+        _fields_ = [
+            ("type", ctypes.c_int),
+            ("display", ctypes.c_void_p),
+            ("resourceid", ctypes.c_ulong),
+            ("serial", ctypes.c_ulong),
+            ("error_code", ctypes.c_ubyte),
+            ("request_code", ctypes.c_ubyte),
+            ("minor_code", ctypes.c_ubyte),
+            ("pad0", ctypes.c_ubyte),
+        ]
+
+    class XcbKeyEvent(ctypes.Structure):
+        _fields_ = [
+            ("response_type", ctypes.c_uint8),
+            ("detail", ctypes.c_uint8),
+            ("sequence", ctypes.c_uint16),
+            ("time", ctypes.c_uint32),
+            ("root", ctypes.c_uint32),
+            ("event", ctypes.c_uint32),
+            ("child", ctypes.c_uint32),
+            ("root_x", ctypes.c_int16),
+            ("root_y", ctypes.c_int16),
+            ("event_x", ctypes.c_int16),
+            ("event_y", ctypes.c_int16),
+            ("state", ctypes.c_uint16),
+            ("same_screen", ctypes.c_uint8),
+            ("pad0", ctypes.c_uint8),
+        ]
+
+    ERROR_HANDLER_FUNC = ctypes.CFUNCTYPE(
+        ctypes.c_int, ctypes.c_void_p, ctypes.POINTER(XErrorEvent)
+    )
+
+    def __init__(self):
+        x11_path = ctypes.util.find_library("X11")
+        if not x11_path:
+            raise RuntimeError("X11 library not found")
+        self.xlib = ctypes.CDLL(x11_path)
+        self.xlib.XOpenDisplay.argtypes = [ctypes.c_char_p]
+        self.xlib.XOpenDisplay.restype = ctypes.c_void_p
+        self.xlib.XDefaultRootWindow.argtypes = [ctypes.c_void_p]
+        self.xlib.XDefaultRootWindow.restype = ctypes.c_uint32
+        self.xlib.XStringToKeysym.argtypes = [ctypes.c_char_p]
+        self.xlib.XStringToKeysym.restype = ctypes.c_ulong
+        self.xlib.XKeysymToKeycode.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+        self.xlib.XKeysymToKeycode.restype = ctypes.c_uint
+        self.xlib.XGrabKey.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.c_uint,
+            ctypes.c_uint32,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+        ]
+        self.xlib.XUngrabKey.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.c_uint,
+            ctypes.c_uint32,
+        ]
+        self.xlib.XFlush.argtypes = [ctypes.c_void_p]
+        self.xlib.XSync.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        self.xlib.XSync.restype = ctypes.c_int
+        self.xlib.XSetErrorHandler.argtypes = [ctypes.c_void_p]
+        self.xlib.XSetErrorHandler.restype = ctypes.c_void_p
+
+        self.display = self.xlib.XOpenDisplay(None)
+        if not self.display:
+            raise RuntimeError("Unable to open X11 display")
+        self.root = self.xlib.XDefaultRootWindow(self.display)
+        self.shortcuts = {}
+        self.grab_masks = {}
+        self.event_filter = None
+        self._last_error_code = None
+        self._error_handler_proc = self.ERROR_HANDLER_FUNC(self._on_error)
+
+    def _string_to_keycode(self, key):
+        keysym = self.xlib.XStringToKeysym(key.encode("ascii"))
+        if not keysym:
+            keysym = self.xlib.XStringToKeysym(key.upper().encode("ascii"))
+        if not keysym:
+            raise ValueError(f"Unsupported key: {key}")
+        keycode = int(self.xlib.XKeysymToKeycode(self.display, keysym))
+        if keycode == 0:
+            raise ValueError(f"Unable to resolve keycode for key: {key}")
+        return keycode
+
+    def _on_error(self, display, error_event):
+        self._last_error_code = error_event.contents.error_code
+        return 0
+
+    def _with_error_trap(self, func, *args):
+        self._last_error_code = None
+        previous = self.xlib.XSetErrorHandler(self._error_handler_proc)
+        try:
+            result = func(*args)
+            self.xlib.XSync(self.display, 0)
+        finally:
+            self.xlib.XSetErrorHandler(previous)
+        return result, self._last_error_code
+
+    def install_shortcut(self, modifiers, key, shortcut_id, callback):
+        mod_value = 0
+        invalid_mods = [m for m in modifiers if m not in self.MODIFIER_MAP]
+        if invalid_mods:
+            raise ValueError(f"Unsupported modifiers: {set(invalid_mods)}")
+        for mod in modifiers:
+            mod_value |= self.MODIFIER_MAP[mod]
+
+        keycode = self._string_to_keycode(key)
+
+        GrabModeAsync = 1
+        owner_events = 1
+
+        masks = [
+            mod_value,
+            mod_value | self.LOCK_MASK,
+            mod_value | self.MOD2_MASK,
+            mod_value | self.LOCK_MASK | self.MOD2_MASK,
+        ]
+
+        success = True
+        registered_masks = []
+        for mask in masks:
+            _, error_code = self._with_error_trap(
+                self.xlib.XGrabKey,
+                self.display,
+                keycode,
+                mask,
+                self.root,
+                owner_events,
+                GrabModeAsync,
+                GrabModeAsync,
+            )
+            if error_code is not None:
+                success = False
+                break
+            registered_masks.append(mask)
+
+        self.xlib.XFlush(self.display)
+
+        if success:
+            self.shortcuts[shortcut_id] = {
+                "callback": callback,
+                "keycode": keycode,
+                "modifiers": mod_value,
+            }
+            self.grab_masks[shortcut_id] = masks
+            return True
+        else:
+            for registered_mask in registered_masks:
+                self._with_error_trap(
+                    self.xlib.XUngrabKey,
+                    self.display,
+                    keycode,
+                    registered_mask,
+                    self.root,
+                )
+            self.xlib.XFlush(self.display)
+        return False
+
+    def remove_shortcut(self, shortcut_id):
+        if shortcut_id not in self.shortcuts:
+            return False
+        keycode = self.shortcuts[shortcut_id]["keycode"]
+        masks = self.grab_masks.get(shortcut_id, [])
+        for mask in masks:
+            self._with_error_trap(
+                self.xlib.XUngrabKey,
+                self.display,
+                keycode,
+                mask,
+                self.root,
+            )
+        self.xlib.XFlush(self.display)
+        del self.shortcuts[shortcut_id]
+        self.grab_masks.pop(shortcut_id, None)
+        return True
+
+    def process_message(self, msg):
+        return False
+
+    def _handle_key_event(self, keycode, state):
+        normalized = state & ~(self.LOCK_MASK | self.MOD2_MASK)
+        for shortcut in self.shortcuts.values():
+            if (
+                shortcut["keycode"] == keycode
+                and shortcut["modifiers"] == normalized
+            ):
+                shortcut["callback"]()
+                return True
+        return False
+
+    def install_event_handler(self, app):
+        class LinuxEventFilter(QAbstractNativeEventFilter):
+            XCB_KEY_PRESS = 2
+
+            def __init__(self, backend):
+                super().__init__()
+                self.backend = backend
+
+            def nativeEventFilter(self, eventType, message):
+                if eventType in (b"xcb_generic_event_t", b"x11_generic_event"):
+                    event = ctypes.cast(
+                        ctypes.c_void_p(int(message)),
+                        ctypes.POINTER(LinuxShortcutBackend.XcbKeyEvent),
+                    ).contents
+                    if event.response_type & 0x7F == self.XCB_KEY_PRESS:
+                        if self.backend._handle_key_event(event.detail, event.state):
+                            return True, 0
+                return False, 0
+
+        self.event_filter = LinuxEventFilter(self)
+        app.installNativeEventFilter(self.event_filter)
+
+
 class ShortcutManager:
     @staticmethod
     def get_backend():
-        if platform.system() == "Windows":
+        system = platform.system()
+        if system == "Windows":
             return WindowsShortcutBackend()
+        if system == "Darwin":
+            return MacShortcutBackend()
+        if system == "Linux":
+            return LinuxShortcutBackend()
         raise NotImplementedError(f"Unsupported platform: {platform.system()}")
 
     def __init__(self, app, shortcuts_dict, run_pipeline):
@@ -142,18 +572,32 @@ class ShortcutManager:
 
     def setup_platform_shortcuts(self):
         platform_key = platform.system().lower()
-        platform_shortcuts = self.shortcuts_dict.get(platform_key, [])
-        for shortcut in platform_shortcuts:
-            action = shortcut["action"]
-            # Fix closure with default argument
-            callback = lambda act=action: self.run_pipeline(act)
-            shortcut_id = self.assign_shortcut(shortcut["shortcut_str"], callback)
-            if shortcut_id:
-                print(
-                    f"Registered shortcut '{shortcut['shortcut_str']}' for action '{action}' (ID: {shortcut_id})"
-                )
-            else:
-                print(f"Could not register shortcut '{shortcut['shortcut_str']}'")
+        candidate_keys = [platform_key]
+        if platform_key == "darwin":
+            candidate_keys.append("macos")
+        elif platform_key == "windows":
+            candidate_keys.extend(["win32", "win"])
+        elif platform_key == "linux":
+            candidate_keys.append("unix")
+        candidate_keys.append("default")
+
+        seen = set()
+        for key in candidate_keys:
+            shortcuts = self.shortcuts_dict.get(key, [])
+            for shortcut in shortcuts:
+                identifier = (shortcut["shortcut_str"], shortcut["action"])
+                if identifier in seen:
+                    continue
+                seen.add(identifier)
+                action = shortcut["action"]
+                callback = lambda act=action: self.run_pipeline(act)
+                shortcut_id = self.assign_shortcut(shortcut["shortcut_str"], callback)
+                if shortcut_id:
+                    print(
+                        f"Registered shortcut '{shortcut['shortcut_str']}' for action '{action}' (ID: {shortcut_id})"
+                    )
+                else:
+                    print(f"Could not register shortcut '{shortcut['shortcut_str']}'")
 
     def unassign_shortcut(self, shortcut_id):
         return self.backend.remove_shortcut(shortcut_id)

--- a/test/main.py
+++ b/test/main.py
@@ -34,7 +34,19 @@ DEFAULT_CONFIG = {
             {"shortcut_str": "ctrl+alt+x", "action": "text_extraction"},
             {"shortcut_str": "ctrl+alt+c", "action": "table"},
             {"shortcut_str": "ctrl+alt+s", "action": "chem2smiles"},
-        ]
+        ],
+        "darwin": [
+            {"shortcut_str": "ctrl+alt+z", "action": "math2latex"},
+            {"shortcut_str": "ctrl+alt+x", "action": "text_extraction"},
+            {"shortcut_str": "ctrl+alt+c", "action": "table"},
+            {"shortcut_str": "ctrl+alt+s", "action": "chem2smiles"},
+        ],
+        "linux": [
+            {"shortcut_str": "ctrl+alt+z", "action": "math2latex"},
+            {"shortcut_str": "ctrl+alt+x", "action": "text_extraction"},
+            {"shortcut_str": "ctrl+alt+c", "action": "table"},
+            {"shortcut_str": "ctrl+alt+s", "action": "chem2smiles"},
+        ],
     },
 }
 os.chdir(os.path.dirname(os.path.abspath(sys.argv[0])))


### PR DESCRIPTION
## Summary
- add native Carbon-based shortcut backend for macOS and X11-based backend for Linux
- update shortcut manager to select new backends and support multiple platform-specific shortcut lists
- extend default configuration and documentation with macOS and Linux shortcut entries

## Testing
- python -m compileall shortcuts.py main.py test/main.py

------
https://chatgpt.com/codex/tasks/task_e_68c8b3a747f4832185725e001ee39283