### PR TITLE
Refactor chat UI and API management into modules

### DIFF
--- a/api_manager.py
+++ b/api_manager.py
@@ -1,0 +1,231 @@
+"""API manager classes handling background Gemini requests for screenshots and chat."""
+from __future__ import annotations
+
+from typing import List, Dict, Any
+
+from PIL import Image
+from PyQt5.QtCore import QObject, QThread, pyqtSignal, pyqtSlot
+from google import genai
+
+
+class ApiWorker(QObject):
+    """Worker object responsible for screenshot-to-LaTeX requests."""
+
+    finished = pyqtSignal(str, str, Image.Image)  # response_text, action, image
+    error = pyqtSignal(str)
+
+    def __init__(self, client: genai.Client, prompt_text: str, action: str, image: Image.Image):
+        super().__init__()
+        self.client = client
+        self.prompt_text = prompt_text
+        self.action = action
+        self.image = image
+
+    @pyqtSlot()
+    def process(self) -> None:
+        """Execute the Gemini request in a background thread."""
+        try:
+            response = self.client.models.generate_content(
+                model="gemini-2.0-flash", contents=[self.prompt_text, self.image]
+            )
+            response_text = response.text
+
+            if not response_text:
+                raise ValueError("API returned an empty or invalid response")
+
+            response_text = response_text.strip()
+            if response_text.startswith("```latex") or response_text.startswith("```"):
+                response_text = response_text.split("\n", 1)[-1].rsplit("\n", 1)[0]
+            response_text = response_text.strip()
+
+            self.finished.emit(response_text, self.action, self.image)
+        except Exception as exc:  # pragma: no cover - defensive path
+            self.error.emit(str(exc))
+
+
+class ChatApiWorker(QObject):
+    """Worker object responsible for conversational Gemini requests."""
+
+    finished = pyqtSignal(str)
+    error = pyqtSignal(str)
+
+    def __init__(self, client: genai.Client, conversation: List[Dict[str, Any]]):
+        super().__init__()
+        self.client = client
+        self.conversation = conversation
+
+    @pyqtSlot()
+    def process(self) -> None:
+        try:
+            contents: List[str] = []
+            for message in self.conversation:
+                role = message.get("role", "user")
+                content = message.get("content", "").strip()
+                if not content:
+                    continue
+                if role == "assistant":
+                    prefix = "Assistant"
+                elif role == "system":
+                    prefix = "System"
+                else:
+                    prefix = "User"
+                contents.append(f"{prefix}: {content}")
+
+            if not contents:
+                raise ValueError("No content to send to chat API")
+
+            response = self.client.models.generate_content(
+                model="gemini-2.0-flash", contents=contents
+            )
+
+            response_text = (response.text or "").strip()
+            if not response_text:
+                raise ValueError("API returned an empty or invalid response")
+
+            self.finished.emit(response_text)
+        except Exception as exc:  # pragma: no cover - defensive path
+            self.error.emit(str(exc))
+
+
+class ApiManager(QObject):
+    """Manages screenshot pipeline Gemini requests via QThreads."""
+
+    api_response_ready = pyqtSignal(str, str, Image.Image)
+    api_error = pyqtSignal(str)
+
+    def __init__(self, api_key: str):
+        super().__init__()
+        self.client = genai.Client(api_key=api_key)
+        self.thread: QThread | None = None
+        self.worker: ApiWorker | None = None
+        self.api_in_progress = False
+
+    def update_api_key(self, api_key: str) -> None:
+        """Refresh the Gemini client when the API key changes."""
+        self.client = genai.Client(api_key=api_key)
+
+    def send_request(self, image: Image.Image, prompt_text: str, action: str) -> bool:
+        self.api_in_progress = True
+
+        self.thread = QThread()
+        self.worker = ApiWorker(self.client, prompt_text, action, image)
+        self.worker.moveToThread(self.thread)
+        self.thread.started.connect(self.worker.process)
+        self.worker.finished.connect(self._handle_response)
+        self.worker.error.connect(self._handle_error)
+        self.worker.finished.connect(self._cleanup_thread)
+        self.worker.error.connect(self._cleanup_thread)
+        self.thread.start()
+        return True
+
+    @pyqtSlot(str, str, Image.Image)
+    def _handle_response(self, response_text: str, action: str, image: Image.Image) -> None:
+        self.api_response_ready.emit(response_text, action, image)
+        self.api_in_progress = False
+
+    @pyqtSlot(str)
+    def _handle_error(self, error_message: str) -> None:
+        self.api_error.emit(error_message)
+        self.api_in_progress = False
+
+    def _cleanup_thread(self) -> None:
+        if self.thread and self.thread.isRunning():
+            self.thread.quit()
+            self.thread.wait()
+
+        if self.worker:
+            self.worker.deleteLater()
+            self.worker = None
+
+        if self.thread:
+            self.thread.deleteLater()
+            self.thread = None
+
+    def cleanup(self) -> None:
+        if self.thread and self.thread.isRunning():
+            self.thread.quit()
+            self.thread.wait()
+
+        if self.worker:
+            self.worker.deleteLater()
+            self.worker = None
+
+        if self.thread:
+            self.thread.deleteLater()
+            self.thread = None
+
+        self.api_in_progress = False
+
+
+class ChatApiManager(QObject):
+    """Manages chat Gemini requests via QThreads."""
+
+    chat_response_ready = pyqtSignal(str)
+    chat_error = pyqtSignal(str)
+
+    def __init__(self, api_key: str):
+        super().__init__()
+        self.client = genai.Client(api_key=api_key)
+        self.thread: QThread | None = None
+        self.worker: ChatApiWorker | None = None
+        self.chat_in_progress = False
+
+    def update_api_key(self, api_key: str) -> None:
+        self.client = genai.Client(api_key=api_key)
+
+    def send_chat_request(self, conversation: List[Dict[str, Any]]) -> bool:
+        if self.chat_in_progress or not conversation:
+            return False
+
+        conversation_copy = [dict(message) for message in conversation]
+
+        self.thread = QThread()
+        self.worker = ChatApiWorker(self.client, conversation_copy)
+        self.worker.moveToThread(self.thread)
+        self.thread.started.connect(self.worker.process)
+        self.worker.finished.connect(self._handle_response)
+        self.worker.error.connect(self._handle_error)
+        self.worker.finished.connect(self._cleanup_thread)
+        self.worker.error.connect(self._cleanup_thread)
+
+        self.chat_in_progress = True
+        self.thread.start()
+        return True
+
+    @pyqtSlot(str)
+    def _handle_response(self, response_text: str) -> None:
+        self.chat_in_progress = False
+        self.chat_response_ready.emit(response_text)
+
+    @pyqtSlot(str)
+    def _handle_error(self, error_message: str) -> None:
+        self.chat_in_progress = False
+        self.chat_error.emit(error_message)
+
+    def _cleanup_thread(self) -> None:
+        if self.thread and self.thread.isRunning():
+            self.thread.quit()
+            self.thread.wait()
+
+        if self.worker:
+            self.worker.deleteLater()
+            self.worker = None
+
+        if self.thread:
+            self.thread.deleteLater()
+            self.thread = None
+
+    def cleanup(self) -> None:
+        if self.thread and self.thread.isRunning():
+            self.thread.quit()
+            self.thread.wait()
+
+        if self.worker:
+            self.worker.deleteLater()
+            self.worker = None
+
+        if self.thread:
+            self.thread.deleteLater()
+            self.thread = None
+
+        self.chat_in_progress = False

--- a/chat_gui.py
+++ b/chat_gui.py
@@ -1,0 +1,115 @@
+"""PyQt chat window wired to the ChatApiManager."""
+from __future__ import annotations
+
+from typing import List, Dict
+
+from PyQt5.QtCore import pyqtSlot, Qt
+from PyQt5.QtGui import QFont
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QTextEdit,
+    QLineEdit,
+    QPushButton,
+    QFrame,
+)
+
+from api_manager import ChatApiManager
+
+
+class ChatApp(QWidget):
+    """Simple chat UI that delegates API calls to ``ChatApiManager``."""
+
+    def __init__(self, chat_manager: ChatApiManager, parent: QWidget | None = None):
+        super().__init__(parent)
+        if chat_manager is None:
+            raise ValueError("chat_manager is required")
+
+        self.chat_manager = chat_manager
+        self.conversation: List[Dict[str, str]] = []
+        self.awaiting_response = False
+
+        self.chat_manager.chat_response_ready.connect(self._handle_response)
+        self.chat_manager.chat_error.connect(self._handle_error)
+
+        self._init_ui()
+
+    def _init_ui(self) -> None:
+        self.setWindowFlags(Qt.Window | Qt.WindowStaysOnTopHint | Qt.Tool)
+        self.setWindowTitle("Chat Window")
+        self.setGeometry(100, 100, 400, 500)
+
+        layout = QVBoxLayout()
+
+        self.response_area = QTextEdit()
+        self.response_area.setReadOnly(True)
+        self.response_area.setFont(QFont("Arial", 10))
+        self.response_area.setFrameStyle(QFrame.Panel | QFrame.Sunken)
+        self.response_area.setMinimumHeight(300)
+
+        self.input_field = QLineEdit()
+        self.input_field.setPlaceholderText("Type your message here...")
+        self.input_field.setFont(QFont("Arial", 10))
+        self.input_field.returnPressed.connect(self.send_message)
+
+        self.send_button = QPushButton("Send")
+        self.send_button.clicked.connect(self.send_message)
+
+        layout.addWidget(self.response_area)
+        layout.addWidget(self.input_field)
+        layout.addWidget(self.send_button)
+
+        self.setLayout(layout)
+
+    def send_message(self) -> None:
+        if self.awaiting_response:
+            return
+
+        message = self.input_field.text().strip()
+        if not message:
+            return
+
+        self._append_message("You", message)
+        self.input_field.clear()
+
+        pending_message = {"role": "user", "content": message}
+        self.conversation.append(pending_message)
+
+        if not self.chat_manager.send_chat_request(list(self.conversation)):
+            self.conversation.pop()
+            self._append_message(
+                "System", "Unable to send message right now. Please try again."
+            )
+            return
+
+        self.awaiting_response = True
+        self._set_loading_state(True)
+
+    def add_response(self, response: str) -> None:
+        self.conversation.append({"role": "assistant", "content": response})
+        self._append_message("Assistant", response)
+
+    def clear_chat(self) -> None:
+        self.conversation.clear()
+        self.response_area.clear()
+
+    def _append_message(self, speaker: str, message: str) -> None:
+        self.response_area.append(f"{speaker}: {message}")
+        self.response_area.append("")
+
+    def _set_loading_state(self, is_loading: bool) -> None:
+        self.input_field.setDisabled(is_loading)
+        self.send_button.setDisabled(is_loading)
+        self.send_button.setText("Sending..." if is_loading else "Send")
+
+    @pyqtSlot(str)
+    def _handle_response(self, response_text: str) -> None:
+        self.awaiting_response = False
+        self._set_loading_state(False)
+        self.add_response(response_text)
+
+    @pyqtSlot(str)
+    def _handle_error(self, error_message: str) -> None:
+        self.awaiting_response = False
+        self._set_loading_state(False)
+        self._append_message("System", f"Error: {error_message}")


### PR DESCRIPTION
## Summary
- move the ChatApp widget into a new chat_gui module to isolate chat UI concerns from application startup code
- extract ApiManager/ChatApiManager and their workers into an api_manager module so background Gemini logic lives in one place
- update main.py to import the new modules while keeping the screenshot pipeline unchanged

## Testing
- python -m compileall main.py chat_gui.py api_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68c8e0bf6cb48321b1a7bbb7baa5b5fe