### PR TITLE
Centralize resource resolution for architecture recommendations

### DIFF
--- a/resources.py
+++ b/resources.py
@@ -1,0 +1,21 @@
+"""Shared resource utilities for resolving project assets at runtime."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+BASE_DIR = Path(__file__).resolve().parent
+"""Repository root used for locating bundled assets and configuration."""
+
+_BUNDLE_BASE = Path(getattr(sys, "_MEIPASS", BASE_DIR))
+
+
+def resource_path(relative_path: str) -> str:
+    """Return an absolute path for the given asset regardless of bundle state."""
+
+    return str((_BUNDLE_BASE / relative_path).resolve())
+
+
+__all__ = ["BASE_DIR", "resource_path"]


### PR DESCRIPTION
## Summary
- add a shared `resources` module to provide a single base directory and resource lookup helper
- update the main application and history UI to consume the shared helper and tighten image loading lifecycles
- refresh the architecture review to reflect the new resource utilities

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e5df78cda08321a0a917704cad8df7